### PR TITLE
Extending decklist drag

### DIFF
--- a/cardDatabase/static/js/edit_decklist.js
+++ b/cardDatabase/static/js/edit_decklist.js
@@ -303,7 +303,6 @@ $(function() {
                             let previousInputEl = $(dragged).find('.card-quantity input');
                             let input_el = cardMatches.find('.card-quantity input');
                             input_el.val(parseInt(input_el.val()) + parseInt(previousInputEl.val()));
-                            $(dragged).remove();
                         }
                         else if (insertIntoList) {
                             droppedOnCard.before(clonedCard);

--- a/cardDatabase/static/js/edit_decklist.js
+++ b/cardDatabase/static/js/edit_decklist.js
@@ -242,98 +242,103 @@ $(function() {
             .off('drag')
             .off('dragstart')
             .off('dragend')
-
-            .on('drag', function(event) {
+            .on('drag', function (event) {
 
             })
-            .on('dragstart', function(event) {
+            .on('dragstart', function (event) {
+                // Fade out the dragged card and hide the popup so it doesn't appear
+                // in the drag preview.
                 $(this).find('img').removeClass('show-hover');
                 event.target.style.opacity = .5;
                 event.originalEvent.dataTransfer.setDragImage(event.target, 0, 0);
                 dragged = event.target;
             })
-            .on('dragend', function(event) {
+            .on('dragend', function (event) {
                 event.target.style.opacity = 1;
             });
 
-            $('.deck-zone')
-                .off('dragover')
-                .off('drop')
-                .on('dragover', false)
-                .on('drop', function(event) {
-                    event.preventDefault();
-                    console.log(event.target);
+        $('.deck-zone')
+            .off('dragover')
+            .off('drop')
+            .on('dragover', false)
+            .on('drop', function (event) {
+                event.preventDefault();
 
-                    let droppedOnCard = $(event.target).closest('.deck-zone-card');
-                    let droppedOnZone = $(event.target).closest('.deck-zone');
-                    let deckZoneCards = $(droppedOnZone[0]).children('.deck-zone-cards')[0];
+                // Need to check if it was dropped on a card or just on a zone.
+                // Using closest so we can drop it on anything and have it work - for example
+                // if somebody drops it on the title of a zone we still want it to work.
+                let droppedOnCard = $(event.target).closest('.deck-zone-card');
+                let droppedOnZone = $(event.target).closest('.deck-zone');
+                let deckZoneCards = $(droppedOnZone[0]).children('.deck-zone-cards')[0];
 
-                    let previousParent = $(dragged).parent().parent();                    
-                    dragged.style.opacity = 1;
+                let previousParent = $(dragged).parent().parent();
+                dragged.style.opacity = 1;
 
-                    console.log(droppedOnCard);
-                    console.log(droppedOnZone);
+                let insertIntoList;
 
-                    let insertIntoList;
+                if (droppedOnCard.length > 0) {
+                    insertIntoList = true;
+                }
+                else if (droppedOnZone.length > 0) {
+                    insertIntoList = false;
+                }
+                else {
+                    return;
+                }
 
-                    if (droppedOnCard.length > 0) {
-                        insertIntoList = true;
+                let cardExists = false;
+                // Check if the card already exists in the zone
+                let cardMatches = $(deckZoneCards).find(`.deck-zone-card`).filter(function () {
+                    return $(this).find('.deck-zone-card-name').text() === $(dragged).find('.deck-zone-card-name').text();
+                });
+
+                // The existing card logic only runs if it was not dropped on the same zone
+                cardExists = cardMatches.length > 0 && previousParent[0] != droppedOnZone[0];
+
+                // Holding shift duplicates the card instead of moving it
+                if (event.shiftKey) {
+                    let clonedCard = dragged.cloneNode(true);
+
+                    // If the card exists we need to increment the number of cards instead
+                    // of adding a new element.
+                    if (cardExists) {
+                        let previousInputEl = $(dragged).find('.card-quantity input');
+                        let input_el = cardMatches.find('.card-quantity input');
+                        input_el.val(parseInt(input_el.val()) + parseInt(previousInputEl.val()));
                     }
-                    else if (droppedOnZone.length > 0) {
-                        insertIntoList = false;
+                    // If a card is dropped directly onto a card in a list, we want to put it before
+                    // that specific card to allow for reordering.
+                    else if (insertIntoList) {
+                        droppedOnCard.before(clonedCard);
+                    }
+                    // Otherwise, put it at the end of the list as normal.
+                    else {
+                        deckZoneCards.appendChild(clonedCard);
+                    }
+
+                    $(clonedCard).find('.deck-zone-card-name').mouseout(hoverCardMouseOut);
+                    $(clonedCard).find('.deck-zone-card-name').mouseover(hoverCardMouseOver);
+                }
+                else {
+                    if (cardExists) {
+                        let previousInputEl = $(dragged).find('.card-quantity input');
+                        let input_el = cardMatches.find('.card-quantity input');
+                        input_el.val(parseInt(input_el.val()) + parseInt(previousInputEl.val()));
+                        $(dragged).remove();
+                    }
+                    else if (insertIntoList) {
+                        droppedOnCard.before(dragged);
                     }
                     else {
-                        return;
+                        deckZoneCards.appendChild(dragged);
                     }
-                    
-                    let cardExists = false;
-                    // Check if the card already exists in the zone
-                    let cardMatches = $(deckZoneCards).find(`.deck-zone-card`).filter(function(){
-                        return $(this).find('.deck-zone-card-name').text() === $(dragged).find('.deck-zone-card-name').text();
-                    });
+                }
 
-                    console.log(previousParent);
-                    console.log(droppedOnZone);
-
-                    cardExists = cardMatches.length > 0 && previousParent[0] != droppedOnZone[0];
-
-                    if (event.shiftKey) {
-                        let clonedCard = dragged.cloneNode(true);
-                        if (cardExists) {
-                            let previousInputEl = $(dragged).find('.card-quantity input');
-                            let input_el = cardMatches.find('.card-quantity input');
-                            input_el.val(parseInt(input_el.val()) + parseInt(previousInputEl.val()));
-                        }
-                        else if (insertIntoList) {
-                            droppedOnCard.before(clonedCard);
-                        }
-                        else {
-                            deckZoneCards.appendChild(clonedCard);
-                        }
-                        
-                        $(clonedCard).find('.deck-zone-card-name').mouseout(hoverCardMouseOut);
-                        $(clonedCard).find('.deck-zone-card-name').mouseover(hoverCardMouseOver);
-                    }
-                    else {                    
-                        if (cardExists) {
-                            let previousInputEl = $(dragged).find('.card-quantity input');
-                            let input_el = cardMatches.find('.card-quantity input');
-                            input_el.val(parseInt(input_el.val()) + parseInt(previousInputEl.val()));  
-                            $(dragged).remove();
-                        }
-                        else if (insertIntoList) {
-                            droppedOnCard.before(dragged);
-                        }
-                        else {
-                            deckZoneCards.appendChild(dragged);
-                        }
-                    }
-
-                    setupCardClickables();
-                    setupEditableContent();
-                    setupDraggableCards();
-                    setZoneCount(droppedOnZone[0]);
-                    setZoneCount(previousParent);
+                setupCardClickables();
+                setupEditableContent();
+                setupDraggableCards();
+                setZoneCount(droppedOnZone[0]);
+                setZoneCount(previousParent);
             });
     }
 

--- a/cardDatabase/static/js/edit_decklist.js
+++ b/cardDatabase/static/js/edit_decklist.js
@@ -96,6 +96,7 @@ $(function() {
         setupCardOverlay();
         setupCardClickables();
         setupEditableContent();
+        setupDraggableCards();
     });
 
     function hoverCardMouseOver(event){
@@ -238,6 +239,10 @@ $(function() {
 
     function setupDraggableCards() {
         $('.deck-zone-card')
+            .off('drag')
+            .off('dragstart')
+            .off('dragend')
+
             .on('drag', function(event) {
 
             })
@@ -257,23 +262,78 @@ $(function() {
                 .on('dragover', false)
                 .on('drop', function(event) {
                     event.preventDefault();
-                    if (event.target.className == 'deck-zone') {
-                        let deckZoneCards = $(this).children('.deck-zone-cards')[0];
-                        let previousParent = $(dragged).parent().parent();
+                    console.log(event.target);
+
+                    let droppedOnCard = $(event.target).closest('.deck-zone-card');
+                    let droppedOnZone = $(event.target).closest('.deck-zone');
+                    let deckZoneCards = $(droppedOnZone[0]).children('.deck-zone-cards')[0];
+
+                    let previousParent = $(dragged).parent().parent();                    
+                    dragged.style.opacity = 1;
+
+                    console.log(droppedOnCard);
+                    console.log(droppedOnZone);
+
+                    let insertIntoList;
+
+                    if (droppedOnCard.length > 0) {
+                        insertIntoList = true;
+                    }
+                    else if (droppedOnZone.length > 0) {
+                        insertIntoList = false;
+                    }
+                    else {
+                        return;
+                    }
+                    
+                    let cardExists = false;
+                    // Check if the card already exists in the zone
+                    let cardMatches = $(deckZoneCards).find(`.deck-zone-card`).filter(function(){
+                        return $(this).find('.deck-zone-card-name').text() === $(dragged).find('.deck-zone-card-name').text();
+                    });
+
+                    console.log(previousParent);
+                    console.log(droppedOnZone);
+
+                    cardExists = cardMatches.length > 0 && previousParent[0] != droppedOnZone[0];
+
+                    if (event.shiftKey) {
+                        let clonedCard = dragged.cloneNode(true);
+                        if (cardExists) {
+                            let input_el = cardMatches.find('.card-quantity input');
+                            input_el.val(parseInt(input_el.val()) + 1);
+                            $(dragged).remove();
+                        }
+                        else if (insertIntoList) {
+                            droppedOnCard.before(clonedCard);
+                        }
+                        else {
+                            deckZoneCards.appendChild(clonedCard);
+                        }
                         
-                        dragged.style.opacity = 1;
-                        if (event.shiftKey) {
-                            deckZoneCards.appendChild(dragged.cloneNode(true));
+                        $(clonedCard).find('.deck-zone-card-name').mouseout(hoverCardMouseOut);
+                        $(clonedCard).find('.deck-zone-card-name').mouseover(hoverCardMouseOver);
+                    }
+                    else {                    
+                        if (cardExists) {
+                            let input_el = cardMatches.find('.card-quantity input');
+                            input_el.val(parseInt(input_el.val()) + 1);      
+                            $(dragged).remove();
+                        }
+                        else if (insertIntoList) {
+                            droppedOnCard.before(dragged);
                         }
                         else {
                             deckZoneCards.appendChild(dragged);
                         }
+                    }
 
-                        setupCardClickables();
-                        setupEditableContent();
-                        setZoneCount(event.target);
-                        setZoneCount(previousParent);
-            }});
+                    setupCardClickables();
+                    setupEditableContent();
+                    setupDraggableCards();
+                    setZoneCount(droppedOnZone[0]);
+                    setZoneCount(previousParent);
+            });
     }
 
     setupDraggableCards();

--- a/cardDatabase/static/js/edit_decklist.js
+++ b/cardDatabase/static/js/edit_decklist.js
@@ -96,7 +96,6 @@ $(function() {
         setupCardOverlay();
         setupCardClickables();
         setupEditableContent();
-        setupSortable();
     });
 
     function hoverCardMouseOver(event){
@@ -167,7 +166,7 @@ $(function() {
     }
 
     function createCardHtml(name, img_url, card_id){
-        return `<div class="deck-zone-card" data-card-id="${card_id}">
+        return `<div class="deck-zone-card" data-card-id="${card_id}" draggable="true">
                     <div class="card-quantity">
                         <a href="#" class="card-quantity-minus">
                             <span>-</span>
@@ -214,6 +213,7 @@ $(function() {
                 deck_zone.find('.deck-zone-card-name').mouseout(hoverCardMouseOut);
                 deck_zone.find('.deck-zone-card-name').mouseover(hoverCardMouseOver);
                 setupCardClickables();
+                setupDraggableCards();
             } else {
                 // Already exists, just increment the value
                 let input_el = card_matches.find('.card-quantity input');
@@ -235,10 +235,48 @@ $(function() {
         output += `</div></div>`;
         return output;
     }
-    function setupSortable(){
-        jQuery_3_6_0('.deck-zone-cards').sortable({delay: 85});
+
+    function setupDraggableCards() {
+        $('.deck-zone-card')
+            .on('drag', function(event) {
+
+            })
+            .on('dragstart', function(event) {
+                $(this).find('img').removeClass('show-hover');
+                event.target.style.opacity = .5;
+                event.originalEvent.dataTransfer.setDragImage(event.target, 0, 0);
+                dragged = event.target;
+            })
+            .on('dragend', function(event) {
+                event.target.style.opacity = 1;
+            });
+
+            $('.deck-zone')
+                .off('dragover')
+                .off('drop')
+                .on('dragover', false)
+                .on('drop', function(event) {
+                    event.preventDefault();
+                    if (event.target.className == 'deck-zone') {
+                        let deckZoneCards = $(this).children('.deck-zone-cards')[0];
+                        let previousParent = $(dragged).parent().parent();
+                        
+                        dragged.style.opacity = 1;
+                        if (event.shiftKey) {
+                            deckZoneCards.appendChild(dragged.cloneNode(true));
+                        }
+                        else {
+                            deckZoneCards.appendChild(dragged);
+                        }
+
+                        setupCardClickables();
+                        setupEditableContent();
+                        setZoneCount(event.target);
+                        setZoneCount(previousParent);
+            }});
     }
-    setupSortable();
+
+    setupDraggableCards();
 });
 
 window.onbeforeunload = function(e){

--- a/cardDatabase/static/js/edit_decklist.js
+++ b/cardDatabase/static/js/edit_decklist.js
@@ -300,8 +300,9 @@ $(function() {
                     if (event.shiftKey) {
                         let clonedCard = dragged.cloneNode(true);
                         if (cardExists) {
+                            let previousInputEl = $(dragged).find('.card-quantity input');
                             let input_el = cardMatches.find('.card-quantity input');
-                            input_el.val(parseInt(input_el.val()) + 1);
+                            input_el.val(parseInt(input_el.val()) + parseInt(previousInputEl.val()));
                             $(dragged).remove();
                         }
                         else if (insertIntoList) {
@@ -316,8 +317,9 @@ $(function() {
                     }
                     else {                    
                         if (cardExists) {
+                            let previousInputEl = $(dragged).find('.card-quantity input');
                             let input_el = cardMatches.find('.card-quantity input');
-                            input_el.val(parseInt(input_el.val()) + 1);      
+                            input_el.val(parseInt(input_el.val()) + parseInt(previousInputEl.val()));  
                             $(dragged).remove();
                         }
                         else if (insertIntoList) {

--- a/cardDatabase/templates/cardDatabase/html/edit_decklist.html
+++ b/cardDatabase/templates/cardDatabase/html/edit_decklist.html
@@ -16,10 +16,6 @@
 {% block js %}
     <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
     <script src="https://code.jquery.com/ui/1.13.1/jquery-ui.js"></script>
-    <script type="text/javascript">
-        //uses 3.6.0 for sortable (drag and drop), dont want it to override normal jQuery as $, so assign it to a new name, then load jquery from block.super
-        let jQuery_3_6_0 = $.noConflict(true);
-    </script>
     {{ block.super }}
     <script src="{% static 'js/search.js' %}" type="text/javascript"></script>
     <script src="{% static 'js/edit_decklist.js' %}" type="text/javascript"></script>
@@ -50,7 +46,7 @@
                     <div class="deck-zone-cards">
                         {% for card in decklist_cards %}
                             {% if card.zone == zone %}
-                                <div class="deck-zone-card" data-card-id="{{ card.card.card_id }}">
+                                <div class="deck-zone-card" data-card-id="{{ card.card.card_id }}" draggable="true">
                                     <div class="card-quantity">
                                         <a href="#/" class="card-quantity-minus"><span>-</span></a>
                                         <input type="text" class="card-quantity-input" value="{{ card.quantity }}">


### PR DESCRIPTION
Resolves #61 

- drag and drop between zones
- dragging on top of a card in a zone will put the dragged card before it, allowing reordering
- holding shift before releasing the drag will duplicate
- dragging a card into a zone which already exists will add the dragged number of cards to the existing card instead