### PR TITLE
Fixed registration that overwrote CONS variables

### DIFF
--- a/cardDatabase/views/tournament/tournament_constants.py
+++ b/cardDatabase/views/tournament/tournament_constants.py
@@ -54,7 +54,8 @@ ONLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': True,
         'type': FIELD_TYPE_TEXT,
         'maxlength': 200,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     },
     {
         'name': 'lastname',
@@ -62,7 +63,8 @@ ONLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': True,
         'type': FIELD_TYPE_TEXT,
         'maxlength': 200,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     },
     {
         'name': 'email',
@@ -70,7 +72,8 @@ ONLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': True,
         'type': FIELD_TYPE_EMAIL,
         'maxlength': 200,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     },
     {
         'name': 'username',
@@ -78,7 +81,8 @@ ONLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': True,
         'type': FIELD_TYPE_TEXT,
         'maxlength': 200,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     },
     {
         'name': 'additional',
@@ -86,7 +90,8 @@ ONLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': False,
         'type': FIELD_TYPE_TEXTAREA,
         'maxlength': 500,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     }
 ]
 
@@ -97,7 +102,8 @@ OFFLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': True,
         'type': FIELD_TYPE_TEXT,
         'maxlength': 200,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     },
     {
         'name': 'lastname',
@@ -105,7 +111,8 @@ OFFLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': True,
         'type': FIELD_TYPE_TEXT,
         'maxlength': 200,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     },
     {
         'name': 'email',
@@ -113,7 +120,8 @@ OFFLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': True,
         'type': FIELD_TYPE_EMAIL,
         'maxlength': 200,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     },
     {
         'name': 'birth-year',
@@ -121,7 +129,8 @@ OFFLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': True,
         'type': FIELD_TYPE_YEAR,
         'maxlength': 4,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     },
     {
         'name': 'additional',
@@ -129,6 +138,7 @@ OFFLINE_TOURNAMENT_DEFAULT_PLAYER_META_DATA = [
         'required': False,
         'type': FIELD_TYPE_TEXTAREA,
         'maxlength': 500,
-        'class': 'form-control'
+        'class': 'form-control',
+        'value': ''
     }
 ]

--- a/cardDatabase/views/tournament/utils/utilities.py
+++ b/cardDatabase/views/tournament/utils/utilities.py
@@ -1,3 +1,5 @@
+import copy
+
 def check_value_is_meta_data(name, default_meta_data_fields):
     for field in default_meta_data_fields:
         if field['name'] == name:
@@ -5,7 +7,8 @@ def check_value_is_meta_data(name, default_meta_data_fields):
     return False
 
 def map_meta_data(name, value, default_meta_data_fields):
-    for field in default_meta_data_fields:
+    default_fields = copy.deepcopy(default_meta_data_fields)
+    for field in default_fields:
         if field['name'] == name:
             field['value'] = value
             return field


### PR DESCRIPTION
Fixed a bug that causes other players to see the previous registered players data when signing up for a tournament.

The underlying issue was that a CONS variable was being overwritten via reference by a helper function.

Added deepcopy to the helper function so this wont ever happen again, also set value to fix the CONS on deployment.