### PR TITLE
one line fix

### DIFF
--- a/cardDatabase/static/css/edit_decklist_mobile.css
+++ b/cardDatabase/static/css/edit_decklist_mobile.css
@@ -192,6 +192,7 @@
 
 .hover-card-img{
     display: none;
+    max-width: 400px;
 }
 
 .hover-card-img.show-hover{


### PR DESCRIPTION
my big "no card image" results in a hover preview that blocks the screen. this fixes that and makes the hover preview a little smaller on average.

Check the second to last Xeex the Ancient Magic reference on [Crimson Girl in the Sky](https://www.forceofwind.online/card/TAT-057/) for how the issue currently looks like.

**Fix preview:** 
<img width="1032" height="738" alt="image" src="https://github.com/user-attachments/assets/ca6fe09c-497a-464a-bd02-50f289a9689a" />